### PR TITLE
Bulk crap uninstaller included in feed.json

### DIFF
--- a/feed.json
+++ b/feed.json
@@ -1,1 +1,734 @@
-[{"Title":"Notepad++","Link64":"https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.1.9.1/npp.8.1.9.1.Installer.x64.exe","Link":"https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.1.9.1/npp.8.1.9.1.Installer.exe","Tag":"cNPP","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/notepadpp.png","Group":"Coding"},{"Title":"Sublime Text","Link64":"https://download.sublimetext.com/Sublime%20Text%20Build%203211%20x64%20Setup.exe","Link":"https://download.sublimetext.com/Sublime%20Text%20Build%203211%20Setup.exe","Tag":"cSublimeText","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/sublimetext.png","Group":"Coding"},{"Title":"Atom","Link64":"https://github.com/atom/atom/releases/download/v1.58.0/AtomSetup-x64.exe","Link":"https://github.com/atom/atom/releases/download/v1.58.0/AtomSetup.exe","Tag":"cAtom","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/atom.png","Group":"Coding"},{"Title":"VS Codium","Link64":"https://github.com/VSCodium/vscodium/releases/download/1.62.3/VSCodiumUserSetup-x64-1.62.3.exe","Link":"https://github.com/VSCodium/vscodium/releases/download/1.62.3/VSCodiumUserSetup-ia32-1.62.3.exe","Tag":"cCodium","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/vscodium.png","Group":"Coding"},{"Title":"GitHub","Link64":"https://desktop.githubusercontent.com/github-desktop/releases/2.9.4-24101633/GitHubDesktopSetup-x64.exe","Tag":"cGitHub","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/github.png","Group":"Coding"},{"Title":"Sublime Merge","Link64":"https://download.sublimetext.com/sublime_merge_build_2063_x64_setup.exe","Tag":"cSublimeMerge","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/sublimemerge.png","Group":"Coding"},{"Title":"FileZilla","Link64":"https://download.filezilla-project.org/client/FileZilla_3.56.2_win64-setup.exe","Link":"https://download.filezilla-project.org/client/FileZilla_3.56.2_win32-setup.exe","Tag":"cFileZilla","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/filezilla.png","Group":"Coding"},{"Title":"WinSCP","Link":"https://kapetanos-metaforiki.gr:56888/winscp","Tag":"cWinScp","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/winscp.png","Group":"Coding"},{"Title":"Postman","Link64":"https://dl.pstmn.io/download/latest/win64","Link":"https://dl.pstmn.io/download/latest/win32","Tag":"cPostman","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/postman.png","Group":"Coding"},{"Title":"NodeJS","Link":"https://nodejs.org/dist/v16.13.0/node-v16.13.0-x86.msi","Link64":"https://nodejs.org/dist/v16.13.0/node-v16.13.0-x64.msi","Tag":"cNode","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/nodejs.png","Group":"Coding"},{"Title":"XAMPP","Link64":"https://downloadsapachefriends.global.ssl.fastly.net/8.0.12/xampp-windows-x64-8.0.12-0-VS16-installer.exe","Tag":"cXAMPP","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/xampp.png","Group":"Coding"},{"Title":"Putty","Link64":"https://the.earth.li/~sgtatham/putty/latest/w64/putty-64bit-0.76-installer.msi","Link":"https://the.earth.li/~sgtatham/putty/latest/w32/putty-0.76-installer.msi","Tag":"cPutty","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/putty.png","Group":"Coding"},{"Title":"Visual Studio","Link":"https://download.visualstudio.microsoft.com/download/pr/20130c62-1bc8-43d6-b4f0-c20bb7c79113/bee2ebedafcbaaf0d4fe61c9bd50b5884e0149e953cbe2abb6cb142e8c60d389/vs_Community.exe","Tag":"cVS","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/visualstudio.png","Group":"Coding"},{"Title":"VS Code","Link64":"https://code.visualstudio.com/sha/download?build=stable&os=win32-x64-user","Link":"https://code.visualstudio.com/sha/download?build=stable&os=win32-user","Tag":"cVSCode","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/vscode.png","Group":"Coding"},{"Title":"Android Studio","Link64":"https://r6---sn-vuxbavcx-5ui6.gvt1.com/edgedl/android/studio/install/4.1.2.0/android-studio-ide-201.7042882-windows.exe?cms_redirect=yes&mh=N5&mip=85.75.185.149&mm=28&mn=sn-vuxbavcx-5ui6&ms=nvh&mt=1613332358&mv=u&mvi=6&pcm2cms=yes&pl=16&shardbypass=yes","Tag":"cAndroidStudio","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/androidstudio.png","Group":"Coding"},{"Title":"Eclipse","Link64":"https://ftp.snt.utwente.nl/pub/software/eclipse/oomph/epp/2021-09/R/eclipse-inst-jre-win64.exe","Tag":"cEclipse","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/eclipse.png","Group":"Coding"},{"Title":"Python 3","Link64":"https://www.python.org/ftp/python/3.10.0/python-3.10.0-amd64.exe","Link":"https://www.python.org/ftp/python/3.10.0/python-3.10.0.exe","Tag":"cPython3","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/python.png","Group":"Coding"},{"Title":"Python 2","Link64":"https://www.python.org/ftp/python/2.7.18/python-2.7.18.amd64.msi","Link":"https://www.python.org/ftp/python/2.7.18/python-2.7.18.msi","Tag":"cPython2","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/python.png","Group":"Coding"},{"Title":"Java 8 JDK","Link64":"https://javadl.oracle.com/webapps/download/AutoDL?BundleId=244584_d7fc238d0cbf4b0dac67be84580cfb4b","Link":"https://javadl.oracle.com/webapps/download/AutoDL?BundleId=244582_d7fc238d0cbf4b0dac67be84580cfb4b","Tag":"cJava","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/java.png","Group":"Coding"},{"Title":"Mozilla Firefox","Link64":"http://download.mozilla.org/?product=firefox-latest&os=Win64&lang=en-US","Link":"http://download.mozilla.org/?product=firefox-latest&os=Win&lang=en-US","Tag":"cFirefox","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/firefox.png","Group":"Internet"},{"Title":"Mozilla Firefox ESR","Link64":"https://download-installer.cdn.mozilla.net/pub/firefox/releases/91.3.0esr/win64/en-US/Firefox%20Setup%2091.3.0esr.exe","Link":"https://download-installer.cdn.mozilla.net/pub/firefox/releases/91.3.0esr/win32/en-US/Firefox%20Setup%2091.3.0esr.exe","Tag":"cFirefoxESR","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/firefox.png","Group":"Internet"},{"Title":"Chromium","Link64":"https://github.com/Hibbiki/chromium-win64/releases/download/v96.0.4664.45-r929512/mini_installer.sync.exe","Link":"https://github.com/Hibbiki/chromium-win32/releases/download/v96.0.4664.45-r929512/mini_installer.sync.exe","Tag":"cChromium","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/chromium.png","Group":"Internet"},{"Title":"Ungoogled Chromium","Link64":"https://github.com/macchrome/winchrome/releases/download/v96.0.4664.45-r929512-Win64/96.0.4664.45_ungoogled_mini_installer.exe","Tag":"cUGChromium","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/chromium.png","Group":"Internet"},{"Title":"Vivaldi","Link64":"https://downloads.vivaldi.com/stable/Vivaldi.4.3.2439.65.x64.exe","Link":"https://downloads.vivaldi.com/stable/Vivaldi.4.3.2439.65.exe","Tag":"cVivaldi","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/vivaldi.png","Group":"Internet"},{"Title":"Tor Browser","Link64":"https://dist.torproject.org/torbrowser/11.0.1/torbrowser-install-win64-11.0.1_en-US.exe","Link":"https://dist.torproject.org/torbrowser/11.0.1/torbrowser-install-11.0.1_en-US.exe","Tag":"cTor","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/tor.png","Group":"Internet"},{"Title":"Google Chrome","Link64":"https://dl.google.com/tag/s/appguid%3D%7B8A69D345-D564-463C-AFF1-A69D9E530F96%7D%26iid%3D%7B96806E3D-7496-9303-FEC0-8299CB4E05AF%7D%26lang%3Den%26browser%3D3%26usagestats%3D0%26appname%3DGoogle%2520Chrome%26needsadmin%3Dprefers%26ap%3Dx64-stable-statsdef_1%26installdataindex%3Dempty/chrome/install/ChromeStandaloneSetup64.exe","Link":"https://dl.google.com/tag/s/appguid%3D%7B8A69D345-D564-463C-AFF1-A69D9E530F96%7D%26iid%3D%7B96806E3D-7496-9303-FEC0-8299CB4E05AF%7D%26lang%3Den%26browser%3D3%26usagestats%3D0%26appname%3DGoogle%2520Chrome%26needsadmin%3Dprefers%26ap%3Dstable-arch_x86-statsdef_1%26installdataindex%3Dempty/chrome/install/ChromeStandaloneSetup.exe","Tag":"cChrome","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/chrome.png","Group":"Internet"},{"Title":"Microsoft Edge","Link64":"https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/dc298968-ce66-4bf0-ac5b-c274bf03ee7e/MicrosoftEdgeEnterpriseX64.msi","Link":"https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/8d1fd468-c6d9-4ade-8870-d4e0dac4f0fb/MicrosoftEdgeEnterpriseX86.msi","Tag":"cEdge","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/edge.png","Group":"Internet"},{"Title":"Opera","Link64":"https://download3.operacdn.com/pub/opera/desktop/81.0.4196.54/win/Opera_81.0.4196.54_Setup_x64.exe","Link":"https://download3.operacdn.com/pub/opera/desktop/81.0.4196.54/win/Opera_81.0.4196.54_Setup.exe","Tag":"cOpera","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/opera.png","Group":"Internet"},{"Title":"Maxthon","Link64":"https://dl.maxthon.com/mx6/maxthon_6.1.2.3000_x64.exe","Link":"https://dl.maxthon.com/mx6/maxthon_6.1.2.3000_x86.exe","Tag":"cMaxthon","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/maxthon.png","Group":"Internet"},{"Title":"Discord","Link":"https://dl.discordapp.net/distro/app/stable/win/x86/1.0.9002/DiscordSetup.exe","Tag":"cDiscord","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/discord.png","Group":"Internet"},{"Title":"Signal","Link":"https://updates.signal.org/desktop/signal-desktop-win-5.24.0.exe","Tag":"cSignal","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/signal.png","Group":"Internet"},{"Title":"Skype","Link":"https://download.skype.com/s4l/download/win/Skype-8.78.0.159.exe","Tag":"cSkype","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/skype.png","Group":"Internet"},{"Title":"Viber","Link":"https://download.cdn.viber.com/desktop/windows/ViberSetup.exe","Tag":"cViber","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/viber.png","Group":"Internet"},{"Title":"FreeTube","Link64":"https://github.com/FreeTubeApp/FreeTube/releases/download/v0.15.1-beta/freetube-0.15.1-setup-x64.exe","Tag":"cFreeTube","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/freetube.png","Group":"Internet"},{"Title":"TeamViewer","Link":"https://download.teamviewer.com/download/TeamViewer_Setup.exe","Tag":"cTV","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/teamviewer.png","Group":"Internet"},{"Title":"AnyDesk","Link":"https://download.anydesk.com/AnyDesk.exe","Tag":"cAnyDesk","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/anydesk.png","Group":"Internet"},{"Title":"Mozilla Thunderbird","Link64":"http://download.mozilla.org/?product=thunderbird-latest&os=Win64&lang=en-US","Link":"http://download.mozilla.org/?product=thunderbird-latest&os=Win&lang=en-US","Tag":"cThunderbird","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/thunderbird.png","Group":"Internet"},{"Title":"Evernote","Link":"https://cdn1.evernote.com/boron/win/builds/Evernote-10.25.6-win-ddl-ga-3073-setup.exe","Tag":"cEvernote","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/evernote.png","Group":"Internet"},{"Title":"MEGAsync","Link64":"https://mega.nz/MEGAsyncSetup64.exe","Link":"https://mega.nz/MEGAsyncSetup32.exe","Tag":"cMega","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/mega.png","Group":"Internet"},{"Title":"Google Zoom","Link":"https://zoom.us/client/latest/ZoomInstaller.exe","Tag":"cZoom","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/zoom.png","Group":"Internet"},{"Title":"Microsoft Teams","Link64":"https://statics.teams.cdn.office.net/production-windows-x64/1.3.00.32283/Teams_windows_x64.exe","Link":"https://statics.teams.cdn.office.net/production-windows/1.3.00.32283/Teams_windows.exe","Tag":"cMSTeams","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/teams.png","Group":"Internet"},{"Title":"OneDrive","Link":"https://oneclient.sfx.ms/Win/Prod/21.002.0104.0005/OneDriveSetup.exe","Tag":"cOneDrive","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/onedrive.png","Group":"Internet"},{"Title":"qBitTorrent","Link64":"https://netix.dl.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-4.3.9/qbittorrent_4.3.9_x64_setup.exe","Link":"https://deac-ams.dl.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-4.3.9/qbittorrent_4.3.9_setup.exe","Tag":"cQB","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/qbittorrent.png","Group":"Internet"},{"Title":"Deluge","Link":"https://ftp.osuosl.org/pub/deluge/windows/deluge-1.3.15-win32-py2.7.exe","Tag":"cDeluge","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/deluge.png","Group":"Internet"},{"Title":"uTorrent 2.2.1","Link":"https://kapetanos-metaforiki.gr:56888/utorrent2","Tag":"cUT2","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/utorrent.png","Group":"Internet"},{"Title":"uTorrent 3.x","Link":"https://download-hr.utorrent.com/track/stable/endpoint/utorrent/os/windows","Tag":"cUT3","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/utorrent.png","Group":"Internet"},{"Title":"BitTorrent","Link":"https://download-new.utorrent.com/endpoint/bittorrent/os/windows/track/stable/","Tag":"cBT","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/bittorrent.png","Group":"Internet"},{"Title":"Steam","Link":"https://cdn.cloudflare.steamstatic.com/client/installer/SteamSetup.exe","Tag":"cSteam","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/steam.png","Group":"Internet"},{"Title":"Battle.net","Link":"https://eu.battle.net/download/getInstaller?os=win&installer=Battle.net-Setup.exe","Tag":"cBlizzard","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/blizzard.png","Group":"Internet"},{"Title":"Uplay","Link":"https://ubistatic3-a.akamaihd.net/orbit/launcher_installer/UbisoftConnectInstaller.exe","Tag":"cUbi","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/uplay.png","Group":"Internet"},{"Title":"EA Origin","Link":"https://origin-a.akamaihd.net/Origin-Client-Download/origin/live/OriginThinSetup.exe","Tag":"cOrigin","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/origin.png","Group":"Internet"},{"Title":"Epic Games","Link":"https://epicgames-download1.akamaized.net/Builds/UnrealEngineLauncher/Installers/Win32/EpicInstaller-10.19.2.msi?launcherfilename=EpicInstaller-10.19.2.msi","Tag":"cEpicStore","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/epic.png","Group":"Internet"},{"Title":"IrfanView","Link":"http://www.storage.programosy.pl/iview458_setup.exe","Tag":"cIrfan","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/irfanview.png","Group":"GraphicsSound"},{"Title":"Foobar2000","Link":"https://www.foobar2000.org/files/foobar2000_v1.6.8.exe","Tag":"cFoobar","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/foobar.png","Group":"GraphicsSound"},{"Title":"VLC Media Player","Link64":"https://get.videolan.org/vlc/3.0.16/win64/vlc-3.0.16-win64.exe","Link":"https://get.videolan.org/vlc/3.0.16/win32/vlc-3.0.16-win32.exe","Tag":"cVLC","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/vlc.png","Group":"GraphicsSound"},{"Title":"PotPlayer","Link64":"https://t1.daumcdn.net/potplayer/PotPlayer/Version/Latest/PotPlayerSetup64.exe","Link":"https://t1.daumcdn.net/potplayer/PotPlayer/Version/Latest/PotPlayerSetup.exe","Tag":"cPot","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/potplayer.png","Group":"GraphicsSound"},{"Title":"GIMP","Link":"https://gemmei.ftp.acc.umu.se/pub/gimp/gimp/v2.10/windows/gimp-2.10.28-setup.exe","Tag":"cGIMP","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/gimp.png","Group":"GraphicsSound"},{"Title":"Gyazo","Link":"https://files.gyazo.com/setup/Gyazo-4.2.1.exe","Tag":"cGyazo","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/gyazo.png","Group":"GraphicsSound"},{"Title":"Lightshot","Link":"https://app.prntscr.com/build/setup-lightshot.exe","Tag":"cLightShot","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/lightshot.png","Group":"GraphicsSound"},{"Title":"Apple iTunes","Link64":"https://secure-appldnld.apple.com/itunes12/001-50023-20201019-A1CA6082-1239-11EB-990E-FA5946985FC9/iTunes64Setup.exe","Link":"https://secure-appldnld.apple.com/itunes12/001-50021-20201019-A1CAB6C2-1239-11EB-AE89-F95946985FC9/iTunesSetup.exe","Tag":"ciTunes","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/itunes.png","Group":"GraphicsSound"},{"Title":"Spotify","Link":"https://download.scdn.co/SpotifySetup.exe","Tag":"cSpotify","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/spotify.png","Group":"GraphicsSound"},{"Title":"BS.Player","Link":"http://download11.bsplayer.com/download/file/mirror1/bsplayer276.setup.exe","Tag":"cBS","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/bsplayer.png","Group":"GraphicsSound"},{"Title":"MP3 Tag","Link":"https://kapetanos-metaforiki.gr:56888/mp3tag","Tag":"cMp3Tag","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/mp3tag.png","Group":"GraphicsSound"},{"Title":"Audacity","Link":"https://github.com/audacity/audacity/releases/download/Audacity-3.1.2/audacity-win-3.1.2-32bit.exe","Link64":"https://github.com/audacity/audacity/releases/download/Audacity-3.1.2/audacity-win-3.1.2-64bit.exe","Tag":"cAudacity","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/audacity.png","Group":"GraphicsSound"},{"Title":"Blender","Link64":"https://mirror.clarkson.edu/blender/release/Blender2.93/blender-2.93.6-windows-x64.msi","Tag":"cBlender","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/blender.png","Group":"GraphicsSound"},{"Title":"OBS Studio","Link64":"https://github.com/obsproject/obs-studio/releases/download/27.1.3/OBS-Studio-27.1.3-Full-Installer-x64.exe","Link":"https://github.com/obsproject/obs-studio/releases/download/27.1.3/OBS-Studio-27.1.3-Full-Installer-x86.exe","Tag":"cOBS","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/obs.png","Group":"GraphicsSound"},{"Title":"Winamp","Tag":"cWinamp","Link":"https://download.nullsoft.com/winamp/misc/winamp58_3660_beta_full_en-us.exe","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/winamp.png","Group":"GraphicsSound"},{"Title":"ViPER4Windows","Link64":"https://kapetanos-metaforiki.gr:56888/viper64","Link":"https://kapetanos-metaforiki.gr:56888/viper86","Tag":"cViper","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/viper.png","Group":"GraphicsSound"},{"Title":"K-Lite Codec Pack","Link":"https://files2.codecguide.com/K-Lite_Codec_Pack_1653_Mega.exe","Tag":"cCodecs","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/klite.png","Group":"GraphicsSound"},{"Title":"7-zip","Link64":"https://www.7-zip.org/a/7z2106-x64.exe","Link":"https://www.7-zip.org/a/7z2106.exe","Tag":"c7zip","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/7zip.png","Group":"SystemTools"},{"Title":"PeaZip","Link64":"https://github.com/peazip/PeaZip/releases/download/8.3.0/peazip-8.3.0.WIN64.exe","Link":"https://github.com/peazip/PeaZip/releases/download/8.3.0/peazip-8.3.0.WINDOWS.exe","Tag":"cPeaZip","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/peazip.png","Group":"SystemTools"},{"Title":"WinRAR","Link64":"https://www.rarlab.com/rar/winrar-x64-602.exe","Link":"https://www.rarlab.com/rar/wrar602.exe","Tag":"cWinRar","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/winrar.png","Group":"SystemTools"},{"Title":"OpenShell","Link":"https://github.com/Open-Shell/Open-Shell-Menu/releases/download/v4.4.160/OpenShellSetup_4_4_160.exe","Tag":"cOpenShell","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/openshell.png","Group":"SystemTools"},{"Title":"LibreOffice","Link64":"https://kapetanos-metaforiki.gr:56888/libre64.msi","Link":"https://kapetanos-metaforiki.gr:56888/libre86.msi","Tag":"cLibreOffice","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/libreoffice.png","Group":"SystemTools"},{"Title":"Adobe Reader","Link64":"http://ardownload.adobe.com/pub/adobe/acrobat/win/AcrobatDC/2100120135/AcroRdrDCx642100120135_en_US.exe","Link":"https://ardownload2.adobe.com/pub/adobe/reader/win/AcrobatDC/2001320074/AcroRdrDC2001320074_en_US.exe","Tag":"cAdobeReader","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/adobereader.png","Group":"SystemTools"},{"Title":"SumatraPDF","Link64":"https://kjkpubsf.sfo2.digitaloceanspaces.com/software/sumatrapdf/rel/SumatraPDF-3.3.3-64-install.exe","Link":"https://kjkpubsf.sfo2.digitaloceanspaces.com/software/sumatrapdf/rel/SumatraPDF-3.3.3-install.exe","Tag":"cSumatra","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/sumatrapdf.png","Group":"SystemTools"},{"Title":"Foxit Reader","Link":"https://cdn01.foxitsoftware.com/pub/foxit/reader/desktop/win/11.x/11.1/en_us/FoxitPDFReader111_Setup.exe","Tag":"cFoxit","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/foxit.png","Group":"SystemTools"},{"Title":".NET Framework 3.5","Link":"https://download.microsoft.com/download/2/0/E/20E90413-712F-438C-988E-FDAA79A8AC3D/dotnetfx35.exe","Tag":"cNF35","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/netfw.png","Group":"SystemTools"},{"Title":".NET Framework 4.0","Link":"https://download.microsoft.com/download/9/5/A/95A9616B-7A37-4AF6-BC36-D6EA96C8DAAE/dotNetFx40_Full_x86_x64.exe","Tag":"cNF40","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/netfw.png","Group":"SystemTools"},{"Title":".NET Framework 4.5.2","Link":"https://download.microsoft.com/download/E/2/1/E21644B5-2DF2-47C2-91BD-63C560427900/NDP452-KB2901907-x86-x64-AllOS-ENU.exe","Tag":"cNF452","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/netfw.png","Group":"SystemTools"},{"Title":".NET Framework 4.7.2","Link":"https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe","Tag":"cNF472","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/netfw.png","Group":"SystemTools"},{"Title":".NET Framework 4.8","Link":"https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe","Tag":"cNF48","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/netfw.png","Group":"SystemTools"},{"Title":"Visual C++ AiO","Link":"https://kapetanos-metaforiki.gr:56888/vcpp","Tag":"cVCPP","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/visualcpp.png","Group":"SystemTools"},{"Title":"DirectX","Link":"https://download.microsoft.com/download/8/4/A/84A35BF1-DAFE-4AE8-82AF-AD2AE20B6B14/directx_Jun2010_redist.exe","Tag":"cDX","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/directx.png","Group":"SystemTools"},{"Title":"F.lux","Link":"https://justgetflux.com/flux-setup.exe","Tag":"cFlux","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/flux.png","Group":"SystemTools"},{"Title":"WinCDEmu","Link":"https://github.com/sysprogs/WinCDEmu/releases/download/v4.1/WinCDEmu-4.1.exe","Tag":"cWCDE","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/wincdemu.png","Group":"SystemTools"},{"Title":"IObit Uninstaller","Link":"https://cdn.iobit.com/dl/iobituninstaller.exe","Tag":"cIObitU","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/iobituninstall.png","Group":"SystemTools"},{"Title":"IObit Smart Defrag","Link":"https://cdn.iobit.com/dl/smart-defrag-setup.exe","Tag":"cIObitSD","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/iobitdefrag.png","Group":"SystemTools"},{"Title":"IObit Software Updater","Link":"https://cdn.iobit.com/dl/iobit-software-updater-setup.exe","Tag":"cIObitSU","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/iobitupdater.png","Group":"SystemTools"},{"Title":"IObit Driver Booster","Link":"https://cdn.iobit.com/dl/driver_booster_setup.exe","Tag":"cIObitDB","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/iobitdrivers.png","Group":"SystemTools"},{"Title":"Revo Uninstaller","Link":"https://download.revouninstaller.com/download/revosetup.exe","Tag":"cRevo","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/revo.png","Group":"SystemTools"},{"Title":"DDU","Link":"https://www.wagnardsoft.com/DDU/download/DDU%20v18.0.4.6.exe","Tag":"cDDU","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/ddu.png","Group":"SystemTools"},{"Title":"Anti-Exploit","Link":"https://kapetanos-metaforiki.gr:56888/antiexploit","Tag":"cAntiExploit","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/antiexploit.png","Group":"SystemTools"},{"Title":"Malwarebytes","Link":"https://data-cdn.mbamupdates.com/web/mb4-setup-consumer/MBSetup.exe","Tag":"cMalwarebytes","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/malwarebytes.png","Group":"SystemTools"},{"Title":"Rufus","Link":"https://github.com/pbatard/rufus/releases/download/v3.17/rufus-3.17.exe","Tag":"cRufus","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/rufus.png","Group":"SystemTools"},{"Title":"Universal USB Installer","Link":"https://www.pendrivelinux.com/downloads/Universal-USB-Installer/Universal-USB-Installer-2.0.0.8.exe","Tag":"cUUI","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/uui.png","Group":"SystemTools"},{"Title":"Balena Etcher","Link":"https://github.com/balena-io/etcher/releases/download/v1.7.0/balenaEtcher-Setup-1.7.0.exe","Tag":"cBalena","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/balena.png","Group":"SystemTools"},{"Title":"WireShark","Link":"https://1.eu.dl.wireshark.org/win32/Wireshark-win32-3.4.10.exe","Link64":"https://1.eu.dl.wireshark.org/win64/Wireshark-win64-3.4.10.exe","Tag":"cWireshark","Image":"https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/wireshark.png","Group":"Internet"}]
+[
+    {
+        "Title": "Notepad++",
+        "Link64": "https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.1.9.1/npp.8.1.9.1.Installer.x64.exe",
+        "Link": "https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.1.9.1/npp.8.1.9.1.Installer.exe",
+        "Tag": "cNPP",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/notepadpp.png",
+        "Group": "Coding"
+    },
+    {
+        "Title": "Sublime Text",
+        "Link64": "https://download.sublimetext.com/Sublime%20Text%20Build%203211%20x64%20Setup.exe",
+        "Link": "https://download.sublimetext.com/Sublime%20Text%20Build%203211%20Setup.exe",
+        "Tag": "cSublimeText",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/sublimetext.png",
+        "Group": "Coding"
+    },
+    {
+        "Title": "Atom",
+        "Link64": "https://github.com/atom/atom/releases/download/v1.58.0/AtomSetup-x64.exe",
+        "Link": "https://github.com/atom/atom/releases/download/v1.58.0/AtomSetup.exe",
+        "Tag": "cAtom",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/atom.png",
+        "Group": "Coding"
+    },
+    {
+        "Title": "VS Codium",
+        "Link64": "https://github.com/VSCodium/vscodium/releases/download/1.62.3/VSCodiumUserSetup-x64-1.62.3.exe",
+        "Link": "https://github.com/VSCodium/vscodium/releases/download/1.62.3/VSCodiumUserSetup-ia32-1.62.3.exe",
+        "Tag": "cCodium",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/vscodium.png",
+        "Group": "Coding"
+    },
+    {
+        "Title": "GitHub",
+        "Link64": "https://desktop.githubusercontent.com/github-desktop/releases/2.9.4-24101633/GitHubDesktopSetup-x64.exe",
+        "Tag": "cGitHub",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/github.png",
+        "Group": "Coding"
+    },
+    {
+        "Title": "Sublime Merge",
+        "Link64": "https://download.sublimetext.com/sublime_merge_build_2063_x64_setup.exe",
+        "Tag": "cSublimeMerge",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/sublimemerge.png",
+        "Group": "Coding"
+    },
+    {
+        "Title": "FileZilla",
+        "Link64": "https://download.filezilla-project.org/client/FileZilla_3.56.2_win64-setup.exe",
+        "Link": "https://download.filezilla-project.org/client/FileZilla_3.56.2_win32-setup.exe",
+        "Tag": "cFileZilla",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/filezilla.png",
+        "Group": "Coding"
+    },
+    {
+        "Title": "WinSCP",
+        "Link": "https://kapetanos-metaforiki.gr:56888/winscp",
+        "Tag": "cWinScp",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/winscp.png",
+        "Group": "Coding"
+    },
+    {
+        "Title": "Postman",
+        "Link64": "https://dl.pstmn.io/download/latest/win64",
+        "Link": "https://dl.pstmn.io/download/latest/win32",
+        "Tag": "cPostman",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/postman.png",
+        "Group": "Coding"
+    },
+    {
+        "Title": "NodeJS",
+        "Link": "https://nodejs.org/dist/v16.13.0/node-v16.13.0-x86.msi",
+        "Link64": "https://nodejs.org/dist/v16.13.0/node-v16.13.0-x64.msi",
+        "Tag": "cNode",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/nodejs.png",
+        "Group": "Coding"
+    },
+    {
+        "Title": "XAMPP",
+        "Link64": "https://downloadsapachefriends.global.ssl.fastly.net/8.0.12/xampp-windows-x64-8.0.12-0-VS16-installer.exe",
+        "Tag": "cXAMPP",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/xampp.png",
+        "Group": "Coding"
+    },
+    {
+        "Title": "Putty",
+        "Link64": "https://the.earth.li/~sgtatham/putty/latest/w64/putty-64bit-0.76-installer.msi",
+        "Link": "https://the.earth.li/~sgtatham/putty/latest/w32/putty-0.76-installer.msi",
+        "Tag": "cPutty",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/putty.png",
+        "Group": "Coding"
+    },
+    {
+        "Title": "Visual Studio",
+        "Link": "https://download.visualstudio.microsoft.com/download/pr/20130c62-1bc8-43d6-b4f0-c20bb7c79113/bee2ebedafcbaaf0d4fe61c9bd50b5884e0149e953cbe2abb6cb142e8c60d389/vs_Community.exe",
+        "Tag": "cVS",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/visualstudio.png",
+        "Group": "Coding"
+    },
+    {
+        "Title": "VS Code",
+        "Link64": "https://code.visualstudio.com/sha/download?build=stable&os=win32-x64-user",
+        "Link": "https://code.visualstudio.com/sha/download?build=stable&os=win32-user",
+        "Tag": "cVSCode",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/vscode.png",
+        "Group": "Coding"
+    },
+    {
+        "Title": "Android Studio",
+        "Link64": "https://r6---sn-vuxbavcx-5ui6.gvt1.com/edgedl/android/studio/install/4.1.2.0/android-studio-ide-201.7042882-windows.exe?cms_redirect=yes&mh=N5&mip=85.75.185.149&mm=28&mn=sn-vuxbavcx-5ui6&ms=nvh&mt=1613332358&mv=u&mvi=6&pcm2cms=yes&pl=16&shardbypass=yes",
+        "Tag": "cAndroidStudio",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/androidstudio.png",
+        "Group": "Coding"
+    },
+    {
+        "Title": "Eclipse",
+        "Link64": "https://ftp.snt.utwente.nl/pub/software/eclipse/oomph/epp/2021-09/R/eclipse-inst-jre-win64.exe",
+        "Tag": "cEclipse",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/eclipse.png",
+        "Group": "Coding"
+    },
+    {
+        "Title": "Python 3",
+        "Link64": "https://www.python.org/ftp/python/3.10.0/python-3.10.0-amd64.exe",
+        "Link": "https://www.python.org/ftp/python/3.10.0/python-3.10.0.exe",
+        "Tag": "cPython3",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/python.png",
+        "Group": "Coding"
+    },
+    {
+        "Title": "Python 2",
+        "Link64": "https://www.python.org/ftp/python/2.7.18/python-2.7.18.amd64.msi",
+        "Link": "https://www.python.org/ftp/python/2.7.18/python-2.7.18.msi",
+        "Tag": "cPython2",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/python.png",
+        "Group": "Coding"
+    },
+    {
+        "Title": "Java 8 JDK",
+        "Link64": "https://javadl.oracle.com/webapps/download/AutoDL?BundleId=244584_d7fc238d0cbf4b0dac67be84580cfb4b",
+        "Link": "https://javadl.oracle.com/webapps/download/AutoDL?BundleId=244582_d7fc238d0cbf4b0dac67be84580cfb4b",
+        "Tag": "cJava",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/java.png",
+        "Group": "Coding"
+    },
+    {
+        "Title": "Mozilla Firefox",
+        "Link64": "http://download.mozilla.org/?product=firefox-latest&os=Win64&lang=en-US",
+        "Link": "http://download.mozilla.org/?product=firefox-latest&os=Win&lang=en-US",
+        "Tag": "cFirefox",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/firefox.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "Mozilla Firefox ESR",
+        "Link64": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/91.3.0esr/win64/en-US/Firefox%20Setup%2091.3.0esr.exe",
+        "Link": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/91.3.0esr/win32/en-US/Firefox%20Setup%2091.3.0esr.exe",
+        "Tag": "cFirefoxESR",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/firefox.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "Chromium",
+        "Link64": "https://github.com/Hibbiki/chromium-win64/releases/download/v96.0.4664.45-r929512/mini_installer.sync.exe",
+        "Link": "https://github.com/Hibbiki/chromium-win32/releases/download/v96.0.4664.45-r929512/mini_installer.sync.exe",
+        "Tag": "cChromium",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/chromium.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "Ungoogled Chromium",
+        "Link64": "https://github.com/macchrome/winchrome/releases/download/v96.0.4664.45-r929512-Win64/96.0.4664.45_ungoogled_mini_installer.exe",
+        "Tag": "cUGChromium",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/chromium.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "Vivaldi",
+        "Link64": "https://downloads.vivaldi.com/stable/Vivaldi.4.3.2439.65.x64.exe",
+        "Link": "https://downloads.vivaldi.com/stable/Vivaldi.4.3.2439.65.exe",
+        "Tag": "cVivaldi",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/vivaldi.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "Tor Browser",
+        "Link64": "https://dist.torproject.org/torbrowser/11.0.1/torbrowser-install-win64-11.0.1_en-US.exe",
+        "Link": "https://dist.torproject.org/torbrowser/11.0.1/torbrowser-install-11.0.1_en-US.exe",
+        "Tag": "cTor",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/tor.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "Google Chrome",
+        "Link64": "https://dl.google.com/tag/s/appguid%3D%7B8A69D345-D564-463C-AFF1-A69D9E530F96%7D%26iid%3D%7B96806E3D-7496-9303-FEC0-8299CB4E05AF%7D%26lang%3Den%26browser%3D3%26usagestats%3D0%26appname%3DGoogle%2520Chrome%26needsadmin%3Dprefers%26ap%3Dx64-stable-statsdef_1%26installdataindex%3Dempty/chrome/install/ChromeStandaloneSetup64.exe",
+        "Link": "https://dl.google.com/tag/s/appguid%3D%7B8A69D345-D564-463C-AFF1-A69D9E530F96%7D%26iid%3D%7B96806E3D-7496-9303-FEC0-8299CB4E05AF%7D%26lang%3Den%26browser%3D3%26usagestats%3D0%26appname%3DGoogle%2520Chrome%26needsadmin%3Dprefers%26ap%3Dstable-arch_x86-statsdef_1%26installdataindex%3Dempty/chrome/install/ChromeStandaloneSetup.exe",
+        "Tag": "cChrome",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/chrome.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "Microsoft Edge",
+        "Link64": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/dc298968-ce66-4bf0-ac5b-c274bf03ee7e/MicrosoftEdgeEnterpriseX64.msi",
+        "Link": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/8d1fd468-c6d9-4ade-8870-d4e0dac4f0fb/MicrosoftEdgeEnterpriseX86.msi",
+        "Tag": "cEdge",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/edge.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "Opera",
+        "Link64": "https://download3.operacdn.com/pub/opera/desktop/81.0.4196.54/win/Opera_81.0.4196.54_Setup_x64.exe",
+        "Link": "https://download3.operacdn.com/pub/opera/desktop/81.0.4196.54/win/Opera_81.0.4196.54_Setup.exe",
+        "Tag": "cOpera",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/opera.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "Maxthon",
+        "Link64": "https://dl.maxthon.com/mx6/maxthon_6.1.2.3000_x64.exe",
+        "Link": "https://dl.maxthon.com/mx6/maxthon_6.1.2.3000_x86.exe",
+        "Tag": "cMaxthon",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/maxthon.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "Discord",
+        "Link": "https://dl.discordapp.net/distro/app/stable/win/x86/1.0.9002/DiscordSetup.exe",
+        "Tag": "cDiscord",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/discord.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "Signal",
+        "Link": "https://updates.signal.org/desktop/signal-desktop-win-5.24.0.exe",
+        "Tag": "cSignal",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/signal.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "Skype",
+        "Link": "https://download.skype.com/s4l/download/win/Skype-8.78.0.159.exe",
+        "Tag": "cSkype",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/skype.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "Viber",
+        "Link": "https://download.cdn.viber.com/desktop/windows/ViberSetup.exe",
+        "Tag": "cViber",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/viber.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "FreeTube",
+        "Link64": "https://github.com/FreeTubeApp/FreeTube/releases/download/v0.15.1-beta/freetube-0.15.1-setup-x64.exe",
+        "Tag": "cFreeTube",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/freetube.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "TeamViewer",
+        "Link": "https://download.teamviewer.com/download/TeamViewer_Setup.exe",
+        "Tag": "cTV",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/teamviewer.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "AnyDesk",
+        "Link": "https://download.anydesk.com/AnyDesk.exe",
+        "Tag": "cAnyDesk",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/anydesk.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "Mozilla Thunderbird",
+        "Link64": "http://download.mozilla.org/?product=thunderbird-latest&os=Win64&lang=en-US",
+        "Link": "http://download.mozilla.org/?product=thunderbird-latest&os=Win&lang=en-US",
+        "Tag": "cThunderbird",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/thunderbird.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "Evernote",
+        "Link": "https://cdn1.evernote.com/boron/win/builds/Evernote-10.25.6-win-ddl-ga-3073-setup.exe",
+        "Tag": "cEvernote",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/evernote.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "MEGAsync",
+        "Link64": "https://mega.nz/MEGAsyncSetup64.exe",
+        "Link": "https://mega.nz/MEGAsyncSetup32.exe",
+        "Tag": "cMega",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/mega.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "Google Zoom",
+        "Link": "https://zoom.us/client/latest/ZoomInstaller.exe",
+        "Tag": "cZoom",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/zoom.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "Microsoft Teams",
+        "Link64": "https://statics.teams.cdn.office.net/production-windows-x64/1.3.00.32283/Teams_windows_x64.exe",
+        "Link": "https://statics.teams.cdn.office.net/production-windows/1.3.00.32283/Teams_windows.exe",
+        "Tag": "cMSTeams",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/teams.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "OneDrive",
+        "Link": "https://oneclient.sfx.ms/Win/Prod/21.002.0104.0005/OneDriveSetup.exe",
+        "Tag": "cOneDrive",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/onedrive.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "qBitTorrent",
+        "Link64": "https://netix.dl.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-4.3.9/qbittorrent_4.3.9_x64_setup.exe",
+        "Link": "https://deac-ams.dl.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-4.3.9/qbittorrent_4.3.9_setup.exe",
+        "Tag": "cQB",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/qbittorrent.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "Deluge",
+        "Link": "https://ftp.osuosl.org/pub/deluge/windows/deluge-1.3.15-win32-py2.7.exe",
+        "Tag": "cDeluge",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/deluge.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "uTorrent 2.2.1",
+        "Link": "https://kapetanos-metaforiki.gr:56888/utorrent2",
+        "Tag": "cUT2",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/utorrent.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "uTorrent 3.x",
+        "Link": "https://download-hr.utorrent.com/track/stable/endpoint/utorrent/os/windows",
+        "Tag": "cUT3",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/utorrent.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "BitTorrent",
+        "Link": "https://download-new.utorrent.com/endpoint/bittorrent/os/windows/track/stable/",
+        "Tag": "cBT",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/bittorrent.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "Steam",
+        "Link": "https://cdn.cloudflare.steamstatic.com/client/installer/SteamSetup.exe",
+        "Tag": "cSteam",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/steam.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "Battle.net",
+        "Link": "https://eu.battle.net/download/getInstaller?os=win&installer=Battle.net-Setup.exe",
+        "Tag": "cBlizzard",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/blizzard.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "Uplay",
+        "Link": "https://ubistatic3-a.akamaihd.net/orbit/launcher_installer/UbisoftConnectInstaller.exe",
+        "Tag": "cUbi",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/uplay.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "EA Origin",
+        "Link": "https://origin-a.akamaihd.net/Origin-Client-Download/origin/live/OriginThinSetup.exe",
+        "Tag": "cOrigin",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/origin.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "Epic Games",
+        "Link": "https://epicgames-download1.akamaized.net/Builds/UnrealEngineLauncher/Installers/Win32/EpicInstaller-10.19.2.msi?launcherfilename=EpicInstaller-10.19.2.msi",
+        "Tag": "cEpicStore",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/epic.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "IrfanView",
+        "Link": "http://www.storage.programosy.pl/iview458_setup.exe",
+        "Tag": "cIrfan",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/irfanview.png",
+        "Group": "GraphicsSound"
+    },
+    {
+        "Title": "Foobar2000",
+        "Link": "https://www.foobar2000.org/files/foobar2000_v1.6.8.exe",
+        "Tag": "cFoobar",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/foobar.png",
+        "Group": "GraphicsSound"
+    },
+    {
+        "Title": "VLC Media Player",
+        "Link64": "https://get.videolan.org/vlc/3.0.16/win64/vlc-3.0.16-win64.exe",
+        "Link": "https://get.videolan.org/vlc/3.0.16/win32/vlc-3.0.16-win32.exe",
+        "Tag": "cVLC",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/vlc.png",
+        "Group": "GraphicsSound"
+    },
+    {
+        "Title": "PotPlayer",
+        "Link64": "https://t1.daumcdn.net/potplayer/PotPlayer/Version/Latest/PotPlayerSetup64.exe",
+        "Link": "https://t1.daumcdn.net/potplayer/PotPlayer/Version/Latest/PotPlayerSetup.exe",
+        "Tag": "cPot",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/potplayer.png",
+        "Group": "GraphicsSound"
+    },
+    {
+        "Title": "GIMP",
+        "Link": "https://gemmei.ftp.acc.umu.se/pub/gimp/gimp/v2.10/windows/gimp-2.10.28-setup.exe",
+        "Tag": "cGIMP",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/gimp.png",
+        "Group": "GraphicsSound"
+    },
+    {
+        "Title": "Gyazo",
+        "Link": "https://files.gyazo.com/setup/Gyazo-4.2.1.exe",
+        "Tag": "cGyazo",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/gyazo.png",
+        "Group": "GraphicsSound"
+    },
+    {
+        "Title": "Lightshot",
+        "Link": "https://app.prntscr.com/build/setup-lightshot.exe",
+        "Tag": "cLightShot",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/lightshot.png",
+        "Group": "GraphicsSound"
+    },
+    {
+        "Title": "Apple iTunes",
+        "Link64": "https://secure-appldnld.apple.com/itunes12/001-50023-20201019-A1CA6082-1239-11EB-990E-FA5946985FC9/iTunes64Setup.exe",
+        "Link": "https://secure-appldnld.apple.com/itunes12/001-50021-20201019-A1CAB6C2-1239-11EB-AE89-F95946985FC9/iTunesSetup.exe",
+        "Tag": "ciTunes",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/itunes.png",
+        "Group": "GraphicsSound"
+    },
+    {
+        "Title": "Spotify",
+        "Link": "https://download.scdn.co/SpotifySetup.exe",
+        "Tag": "cSpotify",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/spotify.png",
+        "Group": "GraphicsSound"
+    },
+    {
+        "Title": "BS.Player",
+        "Link": "http://download11.bsplayer.com/download/file/mirror1/bsplayer276.setup.exe",
+        "Tag": "cBS",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/bsplayer.png",
+        "Group": "GraphicsSound"
+    },
+    {
+        "Title": "MP3 Tag",
+        "Link": "https://kapetanos-metaforiki.gr:56888/mp3tag",
+        "Tag": "cMp3Tag",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/mp3tag.png",
+        "Group": "GraphicsSound"
+    },
+    {
+        "Title": "Audacity",
+        "Link": "https://github.com/audacity/audacity/releases/download/Audacity-3.1.2/audacity-win-3.1.2-32bit.exe",
+        "Link64": "https://github.com/audacity/audacity/releases/download/Audacity-3.1.2/audacity-win-3.1.2-64bit.exe",
+        "Tag": "cAudacity",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/audacity.png",
+        "Group": "GraphicsSound"
+    },
+    {
+        "Title": "Blender",
+        "Link64": "https://mirror.clarkson.edu/blender/release/Blender2.93/blender-2.93.6-windows-x64.msi",
+        "Tag": "cBlender",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/blender.png",
+        "Group": "GraphicsSound"
+    },
+    {
+        "Title": "OBS Studio",
+        "Link64": "https://github.com/obsproject/obs-studio/releases/download/27.1.3/OBS-Studio-27.1.3-Full-Installer-x64.exe",
+        "Link": "https://github.com/obsproject/obs-studio/releases/download/27.1.3/OBS-Studio-27.1.3-Full-Installer-x86.exe",
+        "Tag": "cOBS",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/obs.png",
+        "Group": "GraphicsSound"
+    },
+    {
+        "Title": "Winamp",
+        "Tag": "cWinamp",
+        "Link": "https://download.nullsoft.com/winamp/misc/winamp58_3660_beta_full_en-us.exe",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/winamp.png",
+        "Group": "GraphicsSound"
+    },
+    {
+        "Title": "ViPER4Windows",
+        "Link64": "https://kapetanos-metaforiki.gr:56888/viper64",
+        "Link": "https://kapetanos-metaforiki.gr:56888/viper86",
+        "Tag": "cViper",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/viper.png",
+        "Group": "GraphicsSound"
+    },
+    {
+        "Title": "K-Lite Codec Pack",
+        "Link": "https://files2.codecguide.com/K-Lite_Codec_Pack_1653_Mega.exe",
+        "Tag": "cCodecs",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/klite.png",
+        "Group": "GraphicsSound"
+    },
+    {
+        "Title": "7-zip",
+        "Link64": "https://www.7-zip.org/a/7z2106-x64.exe",
+        "Link": "https://www.7-zip.org/a/7z2106.exe",
+        "Tag": "c7zip",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/7zip.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": "PeaZip",
+        "Link64": "https://github.com/peazip/PeaZip/releases/download/8.3.0/peazip-8.3.0.WIN64.exe",
+        "Link": "https://github.com/peazip/PeaZip/releases/download/8.3.0/peazip-8.3.0.WINDOWS.exe",
+        "Tag": "cPeaZip",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/peazip.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": "WinRAR",
+        "Link64": "https://www.rarlab.com/rar/winrar-x64-602.exe",
+        "Link": "https://www.rarlab.com/rar/wrar602.exe",
+        "Tag": "cWinRar",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/winrar.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": "OpenShell",
+        "Link": "https://github.com/Open-Shell/Open-Shell-Menu/releases/download/v4.4.160/OpenShellSetup_4_4_160.exe",
+        "Tag": "cOpenShell",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/openshell.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": "LibreOffice",
+        "Link64": "https://kapetanos-metaforiki.gr:56888/libre64.msi",
+        "Link": "https://kapetanos-metaforiki.gr:56888/libre86.msi",
+        "Tag": "cLibreOffice",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/libreoffice.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": "Adobe Reader",
+        "Link64": "http://ardownload.adobe.com/pub/adobe/acrobat/win/AcrobatDC/2100120135/AcroRdrDCx642100120135_en_US.exe",
+        "Link": "https://ardownload2.adobe.com/pub/adobe/reader/win/AcrobatDC/2001320074/AcroRdrDC2001320074_en_US.exe",
+        "Tag": "cAdobeReader",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/adobereader.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": "SumatraPDF",
+        "Link64": "https://kjkpubsf.sfo2.digitaloceanspaces.com/software/sumatrapdf/rel/SumatraPDF-3.3.3-64-install.exe",
+        "Link": "https://kjkpubsf.sfo2.digitaloceanspaces.com/software/sumatrapdf/rel/SumatraPDF-3.3.3-install.exe",
+        "Tag": "cSumatra",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/sumatrapdf.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": "Foxit Reader",
+        "Link": "https://cdn01.foxitsoftware.com/pub/foxit/reader/desktop/win/11.x/11.1/en_us/FoxitPDFReader111_Setup.exe",
+        "Tag": "cFoxit",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/foxit.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": ".NET Framework 3.5",
+        "Link": "https://download.microsoft.com/download/2/0/E/20E90413-712F-438C-988E-FDAA79A8AC3D/dotnetfx35.exe",
+        "Tag": "cNF35",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/netfw.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": ".NET Framework 4.0",
+        "Link": "https://download.microsoft.com/download/9/5/A/95A9616B-7A37-4AF6-BC36-D6EA96C8DAAE/dotNetFx40_Full_x86_x64.exe",
+        "Tag": "cNF40",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/netfw.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": ".NET Framework 4.5.2",
+        "Link": "https://download.microsoft.com/download/E/2/1/E21644B5-2DF2-47C2-91BD-63C560427900/NDP452-KB2901907-x86-x64-AllOS-ENU.exe",
+        "Tag": "cNF452",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/netfw.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": ".NET Framework 4.7.2",
+        "Link": "https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe",
+        "Tag": "cNF472",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/netfw.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": ".NET Framework 4.8",
+        "Link": "https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe",
+        "Tag": "cNF48",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/netfw.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": "Visual C++ AiO",
+        "Link": "https://kapetanos-metaforiki.gr:56888/vcpp",
+        "Tag": "cVCPP",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/visualcpp.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": "DirectX",
+        "Link": "https://download.microsoft.com/download/8/4/A/84A35BF1-DAFE-4AE8-82AF-AD2AE20B6B14/directx_Jun2010_redist.exe",
+        "Tag": "cDX",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/directx.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": "F.lux",
+        "Link": "https://justgetflux.com/flux-setup.exe",
+        "Tag": "cFlux",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/flux.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": "WinCDEmu",
+        "Link": "https://github.com/sysprogs/WinCDEmu/releases/download/v4.1/WinCDEmu-4.1.exe",
+        "Tag": "cWCDE",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/wincdemu.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": "IObit Uninstaller",
+        "Link": "https://cdn.iobit.com/dl/iobituninstaller.exe",
+        "Tag": "cIObitU",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/iobituninstall.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": "IObit Smart Defrag",
+        "Link": "https://cdn.iobit.com/dl/smart-defrag-setup.exe",
+        "Tag": "cIObitSD",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/iobitdefrag.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": "IObit Software Updater",
+        "Link": "https://cdn.iobit.com/dl/iobit-software-updater-setup.exe",
+        "Tag": "cIObitSU",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/iobitupdater.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": "IObit Driver Booster",
+        "Link": "https://cdn.iobit.com/dl/driver_booster_setup.exe",
+        "Tag": "cIObitDB",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/iobitdrivers.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": "Revo Uninstaller",
+        "Link": "https://download.revouninstaller.com/download/revosetup.exe",
+        "Tag": "cRevo",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/revo.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": "DDU",
+        "Link": "https://www.wagnardsoft.com/DDU/download/DDU%20v18.0.4.6.exe",
+        "Tag": "cDDU",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/ddu.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": "Anti-Exploit",
+        "Link": "https://kapetanos-metaforiki.gr:56888/antiexploit",
+        "Tag": "cAntiExploit",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/antiexploit.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": "Malwarebytes",
+        "Link": "https://data-cdn.mbamupdates.com/web/mb4-setup-consumer/MBSetup.exe",
+        "Tag": "cMalwarebytes",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/malwarebytes.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": "Rufus",
+        "Link": "https://github.com/pbatard/rufus/releases/download/v3.17/rufus-3.17.exe",
+        "Tag": "cRufus",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/rufus.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": "Universal USB Installer",
+        "Link": "https://www.pendrivelinux.com/downloads/Universal-USB-Installer/Universal-USB-Installer-2.0.0.8.exe",
+        "Tag": "cUUI",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/uui.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": "Balena Etcher",
+        "Link": "https://github.com/balena-io/etcher/releases/download/v1.7.0/balenaEtcher-Setup-1.7.0.exe",
+        "Tag": "cBalena",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/balena.png",
+        "Group": "SystemTools"
+    },
+    {
+        "Title": "WireShark",
+        "Link": "https://1.eu.dl.wireshark.org/win32/Wireshark-win32-3.4.10.exe",
+        "Link64": "https://1.eu.dl.wireshark.org/win64/Wireshark-win64-3.4.10.exe",
+        "Tag": "cWireshark",
+        "Image": "https://raw.githubusercontent.com/hellzerg/optimizer/master/images/feed/wireshark.png",
+        "Group": "Internet"
+    },
+    {
+        "Title": "Bulk Crap Uninstaller",
+        "Link": "https://github.com/Klocman/Bulk-Crap-Uninstaller/releases/download/v5.1/BCUninstaller_5.1_setup.exe",
+        "Link64": "https://github.com/Klocman/Bulk-Crap-Uninstaller/releases/download/v5.1/BCUninstaller_5.1_setup.exe",
+        "Tag": "cBulkCrap",
+        "Image": "",
+        "Group": "SystemTools"
+    }
+]

--- a/feed.json
+++ b/feed.json
@@ -726,9 +726,8 @@
     {
         "Title": "Bulk Crap Uninstaller",
         "Link": "https://github.com/Klocman/Bulk-Crap-Uninstaller/releases/download/v5.1/BCUninstaller_5.1_setup.exe",
-        "Link64": "https://github.com/Klocman/Bulk-Crap-Uninstaller/releases/download/v5.1/BCUninstaller_5.1_setup.exe",
         "Tag": "cBulkCrap",
-        "Image": "",
+        "Image": "https://www.google.com/url?sa=i&url=https%3A%2F%2Fwww.fosshub.com%2FBulk-Crap-Uninstaller.html&psig=AOvVaw2b2sBdU2EoQPM8VI83Gvwl&ust=1643285887619000&source=images&cd=vfe&ved=0CAsQjRxqFwoTCNj214-zz_UCFQAAAAAdAAAAABAD",
         "Group": "SystemTools"
     }
 ]


### PR DESCRIPTION
Hi , I saw you use Revo uninstaller as software remover - can we add free/opensource Bulk crap uninstaller?
I appended it in feed.json, but still unsure how to send you the png icon (it's attached as link on google images)
So before PR I built it with local feed.json to test - is it ok ?  