### PR TITLE
Enable "TreatWarningsAsErrors"

### DIFF
--- a/Optimizer/Controls/ToggleCard.Designer.cs
+++ b/Optimizer/Controls/ToggleCard.Designer.cs
@@ -89,7 +89,7 @@ namespace Optimizer
 
         #endregion
         private System.Windows.Forms.Panel Panel;
-        protected internal System.Windows.Forms.Label Label;
-        protected internal MoonToggle Toggle;
+        internal System.Windows.Forms.Label Label;
+        internal MoonToggle Toggle;
     }
 }

--- a/Optimizer/Forms/SplashForm.Designer.cs
+++ b/Optimizer/Forms/SplashForm.Designer.cs
@@ -81,7 +81,7 @@ namespace Optimizer
         }
 
         #endregion
-        protected internal System.Windows.Forms.Label LoadingStatus;
+        internal System.Windows.Forms.Label LoadingStatus;
         private System.Windows.Forms.PictureBox pictureBox2;
     }
 }

--- a/Optimizer/Optimizer.csproj
+++ b/Optimizer/Optimizer.csproj
@@ -39,6 +39,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -50,6 +51,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup />
   <PropertyGroup>


### PR DESCRIPTION
Since now the project doesn't have any warnings, enabling this option would enforce it to keep that way.