### PR TITLE
Corrected local name for Croatian language

### DIFF
--- a/Optimizer/Constants.cs
+++ b/Optimizer/Constants.cs
@@ -42,7 +42,7 @@
         internal static string VIETNAMESE = "Tiếng Việt";
         internal static string URDU = "لشکری ‍زبان";
         internal static string INDONESIAN = "Bahasa Indonesia";
-        internal static string CROATIAN = "Hrvat";
+        internal static string CROATIAN = "Hrvatski";
 
         internal static string CloudflareDNS = "Cloudflare";
         internal static string OpenDNS = "OpenDNS";

--- a/Optimizer/Forms/FirstRunForm.Designer.cs
+++ b/Optimizer/Forms/FirstRunForm.Designer.cs
@@ -853,7 +853,7 @@ namespace Optimizer
             this.radioCroatian.Size = new System.Drawing.Size(69, 25);
             this.radioCroatian.TabIndex = 136;
             this.radioCroatian.Tag = "";
-            this.radioCroatian.Text = "Hrvat";
+            this.radioCroatian.Text = "Hrvatski";
             this.radioCroatian.UseVisualStyleBackColor = true;
             this.radioCroatian.CheckedChanged += new System.EventHandler(this.radioCroatian_CheckedChanged);
             // 


### PR DESCRIPTION
Corrected the local name for the Croatian language to "Hrvatski".
The former name, "Hrvat" denotes a (male) person from Croatia.